### PR TITLE
go: fix module path

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-puppet
+module github.com/smoeding/tree-sitter-puppet/bindings/go
 
 go 1.22
 


### PR DESCRIPTION
Prior to this change I was unable to this module in Go. After this change importing works correctly.