### PR TITLE
Fix go importing

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_puppet_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-puppet"
+	tree_sitter_puppet "github.com/smoeding/tree-sitter-puppet/bindings/go"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/smoeding/tree-sitter-puppet/bindings/go
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/smoeding/tree-sitter-puppet
 go 1.22
 
 require github.com/tree-sitter/go-tree-sitter v0.24.0
+
+require github.com/mattn/go-pointer v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
+github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
+github.com/tree-sitter/go-tree-sitter v0.24.0 h1:kRZb6aBNfcI/u0Qh8XEt3zjNVnmxTisDBN+kXK0xRYQ=
+github.com/tree-sitter/go-tree-sitter v0.24.0/go.mod h1:x681iFVoLMEwOSIHA1chaLkXlroXEN7WY+VHGFaoDbk=


### PR DESCRIPTION
This is attempt two, as the first attempt,
bf66a6adebbbd3d90fe2d7135d80986ac27bf12b, only worked locally when using a go.mod require directive.

When grabbing a module remotely, Go assumes that all dependent code is in the last directory, e.g.

  go get github.com/smoeding/tree-sitter-puppet/bindings/go

Grabs everything in /go and below, so compilation fails, since the C code in the parent directory cannot be found.

This problem does not occur in local development however, since the parent directory does exist, which is why adding a require directive masks the problem.

Instead we want to use the go.mod file /tree-sitter-puppet/go.mod and delete tree-sitter-puppet/bindings/go.mod. Then a go get will grab the C code as well.

This is also how other tree-sitter bindings are setup:

  https://github.com/tree-sitter-grammars/tree-sitter-yaml

Two other changes are made:

1. Switch the Go tree-sitter bindings from github.com/smacker/go-tree-sitter to github.com/tree-sitter/tree-sitter-puppet, as the latter are unmaintained.
2. Add an indirect dep on github.com/mattn/go-pointer